### PR TITLE
Updated README to note Cobertura and JDK11 restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 
 # Cobertura is not supported in JDK11 so you must downgrade the JDK that Travis uses if you want to use Cobertura with Travis.
+# https://github.com/cobertura/cobertura/issues/381
 jdk:
   - openjdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: java
+
+# Cobertura is not supported in JDK11 so you must downgrade the JDK that Travis uses if you want to use Cobertura with Travis.
+jdk:
+  - openjdk8
+
 sudo: false # faster builds
 
 script: "mvn cobertura:cobertura"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Add to your `.travis.yml` file.
 ```yml
 language: java
 
+# Cobertura is not supported in JDK11 so you must downgrade the JDK that Travis uses if you want to use Cobertura with Travis.
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk8
+
 script: "mvn cobertura:cobertura"
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Add to your `.travis.yml` file.
 language: java
 
 # Cobertura is not supported in JDK11 so you must downgrade the JDK that Travis uses if you want to use Cobertura with Travis.
+# See https://github.com/cobertura/cobertura/issues/381
 jdk:
   - openjdk8
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ language: java
 
 # Cobertura is not supported in JDK11 so you must downgrade the JDK that Travis uses if you want to use Cobertura with Travis.
 jdk:
-  - oraclejdk8
-  - oraclejdk9
   - openjdk8
 
 script: "mvn cobertura:cobertura"


### PR DESCRIPTION
In order to use Cobertura with Travis, you must specify an earlier version of the JDK. Cobertura will not work with travis out of the box as Travis uses JDK 11 (currently). The build will fail with:
```
[ERROR] Failed to execute goal org.codehaus.mojo:cobertura-maven-plugin:2.7:instrument (default-cli) on project xbdd-maven-plugin: Execution default-cli of goal org.codehaus.mojo:cobertura-maven-plugin:2.7:instrument failed: Plugin org.codehaus.mojo:cobertura-maven-plugin:2.7 or one of its dependencies could not be resolved: Could not find artifact com.sun:tools:jar:0 at specified path /usr/local/lib/jvm/openjdk11/../lib/tools.jar -> [Help 1]
```